### PR TITLE
WIP: send real heml emails

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,29 @@ app.post('/', cors({ origin: process.env.NODE_ENV === 'development' ? 'http://lo
     })
 })
 
+app.post('/send', cors({ origin: process.env.NODE_ENV === 'development' ? 'http://localhost:8000' : 'https://heml.io' }), function (req, res) {
+  return HEML(req.body.heml || '')
+    .then((results) => {
+
+      if (results.errors) {
+        results.errors = results.errors.map((error) => {
+          return { selector: error.selector, message: error.toString() }
+        })
+      }
+
+      res.status(200).send("OK")
+
+      return results;
+    })
+    .then((heml) => {
+      // FIXME: This is where we will call sparkpost
+      console.log("doing the magic...")
+      console.log(req.body.email)
+      console.log(heml.html)
+      console.log("the magic is done!")
+    })
+})
+
 app.listen(process.env.PORT || 5000, function () {
   console.log(`listening on port ${process.env.PORT || 5000}!`)
 })


### PR DESCRIPTION
The purpose of this pull request is to add the ability to send real emails through the API. This will allow users to check how HEML formatted emails look like in their email clients.

This is related to [pull request #13 in SparkPost/heml.io](https://github.com/SparkPost/heml.io/pull/13).

This is still work in progress and should not be merged yet.